### PR TITLE
fix: add wrangler.jsonc for Cloudflare Pages deployment

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,0 +1,7 @@
+{
+  "name": "my-portfolio",
+  "compatibility_date": "2026-02-07",
+  "assets": {
+    "directory": "./dist"
+  }
+}


### PR DESCRIPTION
## Summary

- Add `wrangler.jsonc` configuration file to the project root so that `npx wrangler deploy` can locate the Vite build output in `./dist`
- This resolves the "Missing entry-point to Worker script or to assets directory" error during Cloudflare Pages deployment

## Changes

- **`wrangler.jsonc`** (new file): Defines the project name (`my-portfolio`), compatibility date, and static assets directory (`./dist`)

## Test plan

- [ ] Verify `wrangler.jsonc` is valid JSON with comments
- [ ] Trigger a Cloudflare Pages deployment and confirm `npx wrangler deploy` succeeds
- [ ] Confirm the deployed site serves the Vite-built static assets correctly

Closes #60

https://claude.ai/code/session_01QUszLmoboPR2wVYpsp1SaB

## Summary by Sourcery

Deployment:
- Introduce wrangler.jsonc to configure project metadata and point Cloudflare Pages to the Vite build output in ./dist.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added Cloudflare Wrangler configuration file with project settings and deployment directory specification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->