### PR TITLE
docs: add production deployment link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ React + TypeScript + Vite で構築されたポートフォリオサイトです
 | リンク | 説明 |
 |--------|------|
 | [Storybook](https://yellow-seed.github.io/my-portfolio/) | コンポーネントカタログ |
+| [Production](https://my-portfolio.yellow-seed.workers.dev) | デプロイ済みのポートフォリオ |
 
 ## 概要
 


### PR DESCRIPTION
### Motivation
- Make it easy for readers to find and visit the live production site by surfacing the production URL in the repository README (`README.md`).

### Description
- Added a `Production` entry linking to `https://my-portfolio.yellow-seed.workers.dev` in the "デモ・リンク" table of `README.md`.

### Testing
- No automated tests were run for this documentation-only change; CI configuration and test suites were not modified.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6986c30cd390832d85b334a5691d5ba0)

## Summary by Sourcery

Documentation:
- Add a Production link to the README demo links table pointing to the live deployed portfolio.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new Production link row to the Demo/Links table in README.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->